### PR TITLE
Update for Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leafwing_manifest"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Leafwing Studios"]
 homepage = "https://leafwing-studios.com/"
 repository = "https://github.com/leafwing-studios/leafwing_manifest"
@@ -15,11 +15,11 @@ exclude = ["assets/**/*", "tools/**/*", ".github/**/*"]
 members = ["./", "tools/ci"]
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
     "bevy_asset",
     "bevy_state",
 ] }
-bevy_common_assets = { version = "0.11.0", default-features = false }
+bevy_common_assets = { version = "0.12.0", default-features = false }
 serde = "1.0.195"
 thiserror = "1.0.58"
 
@@ -62,7 +62,7 @@ ron = "0.8"
 # Enables non-default features for examples and tests.
 leafwing_manifest = { path = ".", features = ["ron"] }
 # Give us access to the full Bevy default features for examples.
-bevy = { version = "0.14" }
+bevy = { version = "0.15" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.3
+
+- Now support Bevy 0.15
+
 ## 0.2
 
 - Now support Bevy 0.14

--- a/examples/entities_from_manifests.rs
+++ b/examples/entities_from_manifests.rs
@@ -11,7 +11,7 @@
 //! If you need to spawn a scene hierarchy (such as for levels or 3D models), storing a handle to that scene can work well,
 //! or a scene bundle can be added to your custom bundle type.
 
-use bevy::{prelude::*, sprite::Mesh2dHandle, utils::HashMap};
+use bevy::{prelude::*, utils::HashMap};
 use leafwing_manifest::{
     asset_state::SimpleAssetState,
     identifier::Id,
@@ -37,7 +37,7 @@ pub struct Tile {
     color_material: Handle<ColorMaterial>,
     // The same square mesh is used for all tiles,
     // and can be procedurally generated during .
-    mesh: Mesh2dHandle,
+    mesh: Mesh2d,
     tile_type: TileType,
 }
 
@@ -56,10 +56,10 @@ pub struct TileBundle {
     // It also serves as a nice way to filter for tiles in queries.
     id: Id<Tile>,
     tile_type: TileType,
-    material: Handle<ColorMaterial>,
-    mesh: Mesh2dHandle,
-    // Add all of the components needed to render the tile.
-    spatial_bundle: SpatialBundle,
+    material: MeshMaterial2d<ColorMaterial>,
+    mesh: Mesh2d,
+    transform: Transform,
+    visibility: Visibility,
 }
 
 impl TileBundle {
@@ -74,12 +74,13 @@ impl TileBundle {
             tile_type: tile.tile_type,
             // We can use weak clones here and save a tiny bit of work,
             // since the manifest will always store a canonical strong handle to the assets.
-            material: tile.color_material.clone_weak(),
+            material: MeshMaterial2d(tile.color_material.clone_weak()),
             // While the value of the mesh is the same for all tiles, passing around `&Assets<Mesh>` everywhere
             // is miserable. Instead, we sacrifice a little bit of memory to redundantly store the mesh handle in the manifest:
             // like always, the mesh itself is only stored once in the asset storage.
             mesh: tile.mesh.clone(),
-            spatial_bundle: SpatialBundle::from_transform(transform),
+            transform,
+            visibility: Visibility::default(),
         }
     }
 }
@@ -113,7 +114,7 @@ impl Manifest for TileManifest {
         let mut meshes = world.resource_mut::<Assets<Mesh>>();
         let mesh = meshes.add(Mesh::from(Rectangle::new(1.0, 1.0)));
         // This is a thin wrapper around a `Handle<Mesh>`, used in 2D rendering.
-        let mesh_2d = Mesh2dHandle::from(mesh.clone());
+        let mesh_2d = Mesh2d(mesh.clone());
 
         let mut color_materials = world.resource_mut::<Assets<ColorMaterial>>();
 
@@ -151,8 +152,8 @@ pub fn spawn_tiles(mut commands: Commands, tile_manifest: Res<TileManifest>) {
 
     info!("Spawning tiles...");
 
-    // Remember to add the camera bundle to the world, or you won't see anything!
-    commands.spawn(Camera2dBundle::default());
+    // Remember to add the camera to the world, or you won't see anything!
+    commands.spawn(Camera2d);
 
     for (i, tile) in tile_manifest.tiles.values().enumerate() {
         info!("Spawning tile: {:?}", tile);

--- a/examples/items_by_name.rs
+++ b/examples/items_by_name.rs
@@ -12,7 +12,7 @@
 //!
 //! This code is largely copied from the `simple.rs` example: we're just adding constants and a new system to demonstrate the name-based lookups.
 
-use bevy::{log::LogPlugin, prelude::*, utils::HashMap};
+use bevy::{log::LogPlugin, prelude::*, state::app::StatesPlugin, utils::HashMap};
 use leafwing_manifest::{
     asset_state::SimpleAssetState,
     identifier::Id,
@@ -67,7 +67,12 @@ impl Manifest for ItemManifest {
 
 fn main() {
     App::new()
-        .add_plugins((MinimalPlugins, AssetPlugin::default(), LogPlugin::default()))
+        .add_plugins((
+            MinimalPlugins,
+            AssetPlugin::default(),
+            LogPlugin::default(),
+            StatesPlugin,
+        ))
         .init_state::<SimpleAssetState>()
         .add_plugins(ManifestPlugin::<SimpleAssetState>::default())
         .register_manifest::<ItemManifest>("items.ron")

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -6,7 +6,7 @@
 //! See the other examples for more advanced use cases!
 //! The `raw_manifest.rs` example is a good next step that builds upon this example.
 
-use bevy::{app::AppExit, log::LogPlugin, prelude::*, utils::HashMap};
+use bevy::{app::AppExit, log::LogPlugin, prelude::*, state::app::StatesPlugin, utils::HashMap};
 use leafwing_manifest::{
     asset_state::SimpleAssetState,
     identifier::Id,
@@ -69,9 +69,9 @@ impl Manifest for ItemManifest {
 
 fn main() {
     App::new()
-        // leafwing_manifest requires `AssetPlugin` to function
+        // leafwing_manifest requires `AssetPlugin`, and `StatesPlugin` to function
         // This is included in `DefaultPlugins`, but this example is very small, so it only uses the `MinimalPlugins`
-        .add_plugins((MinimalPlugins, AssetPlugin::default(), LogPlugin::default()))
+        .add_plugins((MinimalPlugins, AssetPlugin::default(), LogPlugin::default(), StatesPlugin))
         // This is our simple state, used to navigate the asset loading process.
         .init_state::<SimpleAssetState>()
         // Coordinates asset loading and state transitions.

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -71,7 +71,12 @@ fn main() {
     App::new()
         // leafwing_manifest requires `AssetPlugin`, and `StatesPlugin` to function
         // This is included in `DefaultPlugins`, but this example is very small, so it only uses the `MinimalPlugins`
-        .add_plugins((MinimalPlugins, AssetPlugin::default(), LogPlugin::default(), StatesPlugin))
+        .add_plugins((
+            MinimalPlugins,
+            AssetPlugin::default(),
+            LogPlugin::default(),
+            StatesPlugin,
+        ))
         // This is our simple state, used to navigate the asset loading process.
         .init_state::<SimpleAssetState>()
         // Coordinates asset loading and state transitions.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -99,7 +99,7 @@ impl RegisterManifest for App {
             .add_systems(
                 Update,
                 report_failed_raw_manifest_loading::<M>
-                    .run_if(on_event::<AssetLoadFailedEvent<M::RawManifest>>()),
+                    .run_if(on_event::<AssetLoadFailedEvent<M::RawManifest>>),
             )
             .add_systems(
                 PreUpdate,
@@ -188,7 +188,7 @@ pub enum ProcessingStatus {
 }
 
 /// Information about the loading status of a raw manifest.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct RawManifestStatus {
     /// The path to the manifest file.
     pub path: PathBuf,
@@ -247,7 +247,7 @@ impl RawManifestTracker {
 
         self.raw_manifests
             .values()
-            .all(|status| status.load_state == LoadState::Loaded)
+            .all(|status| status.load_state.is_loaded())
     }
 
     /// Returns true if any registered raw manifests have failed to load.
@@ -256,7 +256,7 @@ impl RawManifestTracker {
 
         self.raw_manifests
             .values()
-            .any(|status| matches!(status.load_state, LoadState::Failed(..)))
+            .any(|status| status.load_state.is_failed())
     }
 
     /// Returns the [`ProcessingStatus`] of the raw manifests.


### PR DESCRIPTION
A largely straightforward update

More significant changes (might require changes from some users):
 - `RawManifestStatus` can no longer be `PartialEq`, `Eq`, as bevy's `LoadState` is not `PartialEq`, `Eq`
 
 Of note:
 I have not changed the Bundle in the example to use required components, but deprecated bundles from bevy (i.e. SpatialBundle) have been replaced with required components.

I also noticed that examples which were using MinimalPlugins have been broken since the update to bevy 0.14, as they did not include `StatesPlugin`, so I have also fixed that. (If you would rather I move that to another PR let me know)